### PR TITLE
Support command level URL query string parameters

### DIFF
--- a/ClickHouse.Client.Tests/Misc/UriBuilderTests.cs
+++ b/ClickHouse.Client.Tests/Misc/UriBuilderTests.cs
@@ -14,11 +14,15 @@ public class UriBuilderTests
         var builder = new ClickHouseUriBuilder(new Uri("http://some.server:123"))
         {
             Database = "DATABASE",
-            CustomParameters = new Dictionary<string, object> { { "a", 1 }, { "b", "c" } },
+            ConnectionQueryStringParameters = new Dictionary<string, object> { { "a", 1 }, { "b", "c" } },
+            CommandQueryStringParameters = new Dictionary<string, object> { { "c", 1 }, { "d", "c" } },
             UseCompression = false,
             Sql = "SELECT 1",
-            SessionId = "SESSION"
+            SessionId = "SESSION",
+            QueryId = "QUERY",
         };
+
+        builder.AddSqlQueryParameter("sqlParameterName", "sqlParameterValue");
 
         var result = new Uri(builder.ToString());
         var @params = HttpUtility.ParseQueryString(result.Query);
@@ -29,8 +33,27 @@ public class UriBuilderTests
         Assert.AreEqual("SELECT 1", @params.Get("query"));
         Assert.AreEqual("1", @params.Get("a"));
         Assert.AreEqual("c", @params.Get("b"));
+        Assert.AreEqual("1", @params.Get("c"));
+        Assert.AreEqual("c", @params.Get("d"));
         Assert.AreEqual("SESSION", @params.Get("session_id"));
         Assert.AreEqual("false", @params.Get("enable_http_compression"));
+        Assert.AreEqual("QUERY", @params.Get("query_id"));
+        Assert.AreEqual("sqlParameterValue", @params.Get("param_sqlParameterName"));
+    }
+
+    [Test]
+    public void CommandQueryStringParametersShouldOverrideConnectionParameters()
+    {
+        var builder = new ClickHouseUriBuilder(new Uri("http://some.server:123"))
+        {
+            ConnectionQueryStringParameters = new Dictionary<string, object> { { "a", 1 } },
+            CommandQueryStringParameters = new Dictionary<string, object> { { "a", 2 } },
+        };
+
+        var result = new Uri(builder.ToString());
+        var @params = HttpUtility.ParseQueryString(result.Query);
+
+        Assert.AreEqual("2", @params.Get("a"));
     }
 #endif
 }

--- a/ClickHouse.Client.Tests/Misc/UriBuilderTests.cs
+++ b/ClickHouse.Client.Tests/Misc/UriBuilderTests.cs
@@ -55,5 +55,107 @@ public class UriBuilderTests
 
         Assert.AreEqual("2", @params.Get("a"));
     }
+
+    [Test]
+    public void ConnectionQueryStringParametersShouldOverrideCommonParameters()
+    {
+        var builder = new ClickHouseUriBuilder(new Uri("http://some.server:123"))
+        {
+            Database = "DATABASE",
+            UseCompression = false,
+            Sql = "SELECT 1",
+            SessionId = "SESSION",
+            QueryId = "QUERY",
+            ConnectionQueryStringParameters = new Dictionary<string, object>
+            {
+                { "database", "overrided" },
+                { "enable_http_compression", "overrided" },
+                { "query", "overrided" },
+                { "session_id", "overrided" },
+                { "query_id", "overrided" },
+            },
+        };
+
+        builder.AddSqlQueryParameter("sqlParameterName", "sqlParameterValue");
+
+        var result = new Uri(builder.ToString());
+        var @params = HttpUtility.ParseQueryString(result.Query);
+
+        Assert.AreEqual("overrided", @params.Get("database"));
+        Assert.AreEqual("overrided", @params.Get("enable_http_compression"));
+        Assert.AreEqual("overrided", @params.Get("query"));
+        Assert.AreEqual("overrided", @params.Get("session_id"));
+        Assert.AreEqual("overrided", @params.Get("query_id"));
+    }
+
+    [Test]
+    public void ConnectionQueryStringParametersShouldOverrideSqlQueryParameters()
+    {
+        var builder = new ClickHouseUriBuilder(new Uri("http://some.server:123"))
+        {
+            ConnectionQueryStringParameters = new Dictionary<string, object>
+            {
+                { "param_sqlParameterName", "overrided" },
+            },
+        };
+
+        builder.AddSqlQueryParameter("sqlParameterName", "sqlParameterValue");
+
+        var result = new Uri(builder.ToString());
+        var @params = HttpUtility.ParseQueryString(result.Query);
+
+        Assert.AreEqual("overrided", @params.Get("param_sqlParameterName"));
+    }
+
+    [Test]
+    public void CommandQueryStringParametersShouldOverrideCommonParameters()
+    {
+        var builder = new ClickHouseUriBuilder(new Uri("http://some.server:123"))
+        {
+            Database = "DATABASE",
+            UseCompression = false,
+            Sql = "SELECT 1",
+            SessionId = "SESSION",
+            QueryId = "QUERY",
+            CommandQueryStringParameters = new Dictionary<string, object>
+            {
+                { "database", "overrided" },
+                { "enable_http_compression", "overrided" },
+                { "query", "overrided" },
+                { "session_id", "overrided" },
+                { "query_id", "overrided" },
+            },
+        };
+
+        builder.AddSqlQueryParameter("sqlParameterName", "sqlParameterValue");
+
+        var result = new Uri(builder.ToString());
+        var @params = HttpUtility.ParseQueryString(result.Query);
+
+        Assert.AreEqual("overrided", @params.Get("database"));
+        Assert.AreEqual("overrided", @params.Get("enable_http_compression"));
+        Assert.AreEqual("overrided", @params.Get("query"));
+        Assert.AreEqual("overrided", @params.Get("session_id"));
+        Assert.AreEqual("overrided", @params.Get("query_id"));
+    }
+
+    [Test]
+    public void CommandQueryStringParametersShouldOverrideSqlQueryParameters()
+    {
+        var builder = new ClickHouseUriBuilder(new Uri("http://some.server:123"))
+        {
+            CommandQueryStringParameters = new Dictionary<string, object>
+            {
+                { "param_sqlParameterName", "overrided" },
+            },
+        };
+
+        builder.AddSqlQueryParameter("sqlParameterName", "sqlParameterValue");
+
+        var result = new Uri(builder.ToString());
+        var @params = HttpUtility.ParseQueryString(result.Query);
+
+        Assert.AreEqual("overrided", @params.Get("param_sqlParameterName"));
+    }
 #endif
 }

--- a/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
+++ b/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
@@ -18,11 +18,9 @@ namespace ClickHouse.Client.Tests.SQL;
 public class SqlSimpleSelectTests : IDisposable
 {
     private readonly ClickHouseConnection connection;
-    private readonly bool useCompression;
 
     public SqlSimpleSelectTests(bool useCompression)
     {
-        this.useCompression = useCompression;
         connection = TestUtilities.GetTestClickHouseConnection(useCompression);
     }
 
@@ -217,9 +215,8 @@ public class SqlSimpleSelectTests : IDisposable
     [FromVersion(23, 7)]
     public async Task ShouldGetResultQueryStats()
     {
-        using var bufferingConnection = TestUtilities.GetTestClickHouseConnection(useCompression);
-        bufferingConnection.CustomSettings.Add("wait_end_of_query", 1);
-        var command = bufferingConnection.CreateCommand();
+        var command = connection.CreateCommand();
+        command.CustomSettings.Add("wait_end_of_query", 1);
         command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
         using var reader = await command.ExecuteReaderAsync();
         var stats = command.QueryStats;

--- a/ClickHouse.Client/ADO/ClickHouseCommand.cs
+++ b/ClickHouse.Client/ADO/ClickHouseCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -22,6 +23,7 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
 {
     private readonly CancellationTokenSource cts = new CancellationTokenSource();
     private readonly ClickHouseParameterCollection commandParameters = new ClickHouseParameterCollection();
+    private Dictionary<string, object> customSettings;
     private ClickHouseConnection connection;
 
     public ClickHouseCommand()
@@ -51,6 +53,12 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
     public string QueryId { get; set; }
 
     public QueryStats QueryStats { get; private set; }
+
+    /// <summary>
+    /// Gets collection of custom settings which will be passed as URL query string parameters.
+    /// </summary>
+    /// <remarks>Not thread-safe.</remarks>
+    public IDictionary<string, object> CustomSettings => customSettings ??= new Dictionary<string, object>();
 
     protected override DbConnection DbConnection
     {
@@ -156,8 +164,8 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
         var uriBuilder = connection.CreateUriBuilder();
         await connection.EnsureOpenAsync().ConfigureAwait(false); // Preserve old behavior
 
-        if (!string.IsNullOrEmpty(QueryId))
-            uriBuilder.CustomParameters.Add("query_id", QueryId);
+        uriBuilder.QueryId = QueryId;
+        uriBuilder.CommandQueryStringParameters = customSettings;
 
         using var postMessage = connection.UseFormDataParameters
             ? BuildHttpRequestMessageWithFormData(
@@ -186,7 +194,9 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
             sqlQuery = commandParameters.ReplacePlaceholders(sqlQuery);
             foreach (ClickHouseDbParameter parameter in commandParameters)
             {
-                uriBuilder.AddQueryParameter(parameter.ParameterName, HttpParameterFormatter.Format(parameter, connection.TypeSettings));
+                uriBuilder.AddSqlQueryParameter(
+                    parameter.ParameterName,
+                    HttpParameterFormatter.Format(parameter, connection.TypeSettings));
             }
         }
 

--- a/ClickHouse.Client/ADO/ClickHouseCommand.cs
+++ b/ClickHouse.Client/ADO/ClickHouseCommand.cs
@@ -23,7 +23,6 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
 {
     private readonly CancellationTokenSource cts = new CancellationTokenSource();
     private readonly ClickHouseParameterCollection commandParameters = new ClickHouseParameterCollection();
-    private Dictionary<string, object> customSettings;
     private ClickHouseConnection connection;
 
     public ClickHouseCommand()
@@ -57,8 +56,7 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
     /// <summary>
     /// Gets collection of custom settings which will be passed as URL query string parameters.
     /// </summary>
-    /// <remarks>Not thread-safe.</remarks>
-    public IDictionary<string, object> CustomSettings => customSettings ??= new Dictionary<string, object>();
+    public IDictionary<string, object> CustomSettings { get; } = new Dictionary<string, object>();
 
     protected override DbConnection DbConnection
     {
@@ -165,7 +163,7 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
         await connection.EnsureOpenAsync().ConfigureAwait(false); // Preserve old behavior
 
         uriBuilder.QueryId = QueryId;
-        uriBuilder.CommandQueryStringParameters = customSettings;
+        uriBuilder.CommandQueryStringParameters = CustomSettings;
 
         using var postMessage = connection.UseFormDataParameters
             ? BuildHttpRequestMessageWithFormData(

--- a/ClickHouse.Client/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Client/ADO/ClickHouseConnection.cs
@@ -355,7 +355,8 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
         Database = database,
         SessionId = session,
         UseCompression = UseCompression,
-        CustomParameters = customSettings.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+        ConnectionQueryStringParameters = customSettings
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
         Sql = sql,
     };
 

--- a/ClickHouse.Client/IClickHouseCommand.cs
+++ b/ClickHouse.Client/IClickHouseCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System.Collections.Generic;
+using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Client.ADO;
@@ -11,4 +12,6 @@ public interface IClickHouseCommand : IDbCommand
     new ClickHouseDbParameter CreateParameter();
 
     Task<ClickHouseRawResult> ExecuteRawResultAsync(CancellationToken cancellationToken);
+
+    IDictionary<string, object> CustomSettings { get; }
 }


### PR DESCRIPTION
preview PR

This PR introduces `CustomSettings` attribute for `ClickHouseCommand` class.

- The values assigned to `CustomSettings` are appended as URL query string parameters.
- This implementation mirrors the existing public contract of `ClickHouseConnection` for consistency.
- Command-level settings specified through `CustomSettings` will take precedence over analogous connection-level settings.

`ClickHouseUriBuilder` tests were added. Some of them demonstrate that both command-level and connection-level custom settings can override common parameters, such as `query`, `session_id`, etc. This behavior might be unintended.